### PR TITLE
[BUG] Add support to Jekyll SEO Tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 gemspec
 
+gem 'jekyll-seo-tag'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 gem 'webrick'

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,5 @@
 title: Deerlin Theme
+tagline: Deerlin is a theme for Jekyll.
 description: Deerlin is a theme developed by Nashira Deer to be used in his websites that uses Jekyll.
 google-analytics:
 logomark:

--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,5 @@ navbar:
     url: /
   - name: Another Page
     url: /another-page
+plugins:
+  - jekyll-seo-tag

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>{{ site.name }}</title>
+        <title>{{ site.title }}</title>
 
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>{{ site.title }}</title>
-
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        
+        {% seo %}
 
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Added support to Jekyll SEO Tag plugin to handle some seo tags like title (fixes #8), description and OpenGraph.