### PR TITLE
[Feature] Add support for setup the website language

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ site.lang | default: "en-US" }}>
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
You can now use `lang:` in the _config.yml to set the website language. fixes #15.