### PR TITLE
[Enhancement] Increase contrast ratio

### DIFF
--- a/_sass/color-dark.scss
+++ b/_sass/color-dark.scss
@@ -19,7 +19,7 @@
     --noscript-background-color: #fff5a5;
     --noscript-border-color: #e48900;
 
-    --code-background-color: #222831;
+    --code-background-color: #161b20;
     --code-font-color: var(--font-color);
     --code-border-color: #3c4245;
 
@@ -28,7 +28,7 @@
     --blockquote-border-color: #f10086;
 
     --table-background-color: #fe83c6;
-    --table-font-color: var(--font-color);
+    --table-font-color: var(--background-color);
     --table-in-border-color: #f10086;
     --table-out-border-color: var(--table-in-border-color);
 

--- a/_sass/deerlin-common.scss
+++ b/_sass/deerlin-common.scss
@@ -30,13 +30,39 @@ noscript div {
     border-radius: 5px;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
     color: var(--theme-color);
     font-weight: bolder;
 }
 
-h1, h2 {
-    border-bottom: 3px solid var(--theme-color);;
+h1,
+h2 {
+    border-bottom: 3px solid var(--theme-color);
+}
+
+h3 {
+    font-size: 1.5em;
+}
+
+h4 {
+    font-size: 1.35em;
+}
+
+h5 {
+    font-size: 1.2em;
+}
+
+h6 {
+    font-size: 1.1em;
+}
+
+main {
+    background-color: var(--background-color);
 }
 
 main a {
@@ -125,7 +151,7 @@ header #title a {
 footer {
     color: var(--footer-font-color);
     text-align: center;
-}   
+}
 
 footer div {
     margin: 0 auto;

--- a/_sass/deerlin-common.scss
+++ b/_sass/deerlin-common.scss
@@ -98,6 +98,7 @@ th {
     padding: 10px;
     background: var(--table-background-color);
     color: var(--table-font-color);
+    font-weight: bold;
     border-left: 1px solid var(--table-in-border-color);
     border-bottom: 1px solid var(--table-in-border-color);
     font-weight: normal;

--- a/_sass/deerlin-common.scss
+++ b/_sass/deerlin-common.scss
@@ -98,7 +98,6 @@ th {
     padding: 10px;
     background: var(--table-background-color);
     color: var(--table-font-color);
-    font-weight: bold;
     border-left: 1px solid var(--table-in-border-color);
     border-bottom: 1px solid var(--table-in-border-color);
     font-weight: normal;


### PR DESCRIPTION
On some elements, the contrast ratio was lower than recommended by the W3C, in this pull, the dark theme color and common style were patched so that the contrast ratio became higher on the affected elements.

## Changes

- Change: Make the background  of the \<code\> element darker.
- Change: Use a dark gray font color, instead of white, for the table headers.
- Change: Increase h3, h4, h5 and h6 font size.